### PR TITLE
Mwalsh/social signup

### DIFF
--- a/addon/components/nypr-account-forms/login.js
+++ b/addon/components/nypr-account-forms/login.js
@@ -2,6 +2,7 @@ import layout from '../../templates/components/nypr-account-forms/login';
 import Component from 'ember-component';
 import set from 'ember-metal/set';
 import get from 'ember-metal/get';
+import { next } from 'ember-runloop';
 import computed from 'ember-computed';
 import service from 'ember-service/inject';
 import Changeset from 'ember-changeset';
@@ -52,11 +53,24 @@ export default Component.extend({
     },
     loginWithFacebook() {
       get(this, 'session').authenticate('authenticator:torii', 'facebook-connect')
+      .then(() => {
+        // because we clear messages when clicking this form,
+        // wait a tick when we add one
+        next(() => {
+          this.get('flashMessages').add({
+            message: messages.socialAuthSignup,
+            type: 'success',
+            sticky: true,
+          });
+        });
+      })
       .catch(() => {
-        this.get('flashMessages').add({
-          message: messages.socialAuthCancelled,
-          type: 'warning',
-          sticky: true,
+        next(() => {
+          this.get('flashMessages').add({
+            message: messages.socialAuthCancelled,
+            type: 'warning',
+            sticky: true,
+          });
         });
       });
     }

--- a/addon/components/nypr-account-forms/login.js
+++ b/addon/components/nypr-account-forms/login.js
@@ -53,30 +53,20 @@ export default Component.extend({
     },
     loginWithFacebook() {
       get(this, 'session').authenticate('authenticator:torii', 'facebook-connect')
-      .then(() => {
-        if (this.get('session').get('isNewSocialUser') === true) {
-          // because we clear flash messages when clicking this form,
-          // wait a tick when we add one in an action that can
-          // be triggered with a click
-          next(() => {
-            this.get('flashMessages').add({
-              message: messages.socialAuthSignup,
-              type: 'success',
-              sticky: true,
-            });
-          });
-        }
-      })
-      .catch(() => {
-        next(() => {
-          this.get('flashMessages').add({
-            message: messages.socialAuthCancelled,
-            type: 'warning',
-            sticky: true,
-          });
-        });
-      });
+      .catch(() => this.onFacebookLoginFailure());
     }
+  },
+  onFacebookLoginFailure() {
+    // because we clear flash messages when clicking this form,
+    // wait a tick when we add one in an action that can
+    // be triggered with a click
+    next(() => {
+      this.get('flashMessages').add({
+        message: messages.socialAuthCancelled,
+        type: 'warning',
+        sticky: true,
+      });
+    });
   },
   authenticate(email, password) {
     return get(this, 'session').authenticate('authenticator:nypr', email, password);

--- a/addon/components/nypr-account-forms/login.js
+++ b/addon/components/nypr-account-forms/login.js
@@ -54,15 +54,18 @@ export default Component.extend({
     loginWithFacebook() {
       get(this, 'session').authenticate('authenticator:torii', 'facebook-connect')
       .then(() => {
-        // because we clear messages when clicking this form,
-        // wait a tick when we add one
-        next(() => {
-          this.get('flashMessages').add({
-            message: messages.socialAuthSignup,
-            type: 'success',
-            sticky: true,
+        if (this.get('session').get('isNewSocialUser') === true) {
+          // because we clear flash messages when clicking this form,
+          // wait a tick when we add one in an action that can
+          // be triggered with a click
+          next(() => {
+            this.get('flashMessages').add({
+              message: messages.socialAuthSignup,
+              type: 'success',
+              sticky: true,
+            });
           });
-        });
+        }
       })
       .catch(() => {
         next(() => {

--- a/addon/components/nypr-account-forms/login.js
+++ b/addon/components/nypr-account-forms/login.js
@@ -3,6 +3,7 @@ import Component from 'ember-component';
 import set from 'ember-metal/set';
 import get from 'ember-metal/get';
 import computed from 'ember-computed';
+import service from 'ember-service/inject';
 import Changeset from 'ember-changeset';
 import LoginValidations from 'nypr-account-settings/validations/nypr-accounts/login';
 import messages from 'nypr-account-settings/validations/nypr-accounts/custom-messages';
@@ -11,6 +12,7 @@ import lookupValidator from 'ember-changeset-validations';
 export default Component.extend({
   layout,
   messages,
+  flashMessages: service(),
   authAPI: null,
   session: null,
   showSocialLogin: false,
@@ -28,6 +30,9 @@ export default Component.extend({
     });
     set(this, 'changeset', new Changeset(get(this, 'fields'), lookupValidator(LoginValidations), LoginValidations));
     get(this, 'changeset').validate();
+  },
+  click() {
+    get(this, 'flashMessages').clearMessages();
   },
   actions: {
     onSubmit() {
@@ -47,7 +52,13 @@ export default Component.extend({
     },
     loginWithFacebook() {
       get(this, 'session').authenticate('authenticator:torii', 'facebook-connect')
-      .catch(() => {});
+      .catch(() => {
+        this.get('flashMessages').add({
+          message: messages.socialAuthCancelled,
+          type: 'warning',
+          sticky: true,
+        });
+      });
     }
   },
   authenticate(email, password) {

--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -41,15 +41,18 @@ export default Component.extend({
     signupWithFacebook() {
       this.get('session').authenticate('authenticator:torii', 'facebook-connect')
       .then(() => {
-        // because we clear messages when clicking this form,
-        // wait a tick when we add one
-        next(() => {
-          this.get('flashMessages').add({
-            message: messages.socialAuthSignup,
-            type: 'success',
-            sticky: true,
+        if (this.get('session').get('isNewSocialUser') === true) {
+          // because we clear flash messages when clicking this form,
+          // wait a tick when we add one in an action that can
+          // be triggered with a click
+          next(() => {
+            this.get('flashMessages').add({
+              message: messages.socialAuthSignup,
+              type: 'success',
+              sticky: true,
+            });
           });
-        });
+        }
       })
       .catch(() => {
         next(() => {

--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -39,7 +39,6 @@ export default Component.extend({
       }
     },
     signupWithFacebook() {
-      this.get('session').set('data.isSigningUpWithThirdParty', true);
       this.get('session').authenticate('authenticator:torii', 'facebook-connect')
       .then(() => {
         // because we clear messages when clicking this form,

--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -39,31 +39,21 @@ export default Component.extend({
       }
     },
     signupWithFacebook() {
-      this.get('session').authenticate('authenticator:torii', 'facebook-connect')
-      .then(() => {
-        if (this.get('session').get('isNewSocialUser') === true) {
-          // because we clear flash messages when clicking this form,
-          // wait a tick when we add one in an action that can
-          // be triggered with a click
-          next(() => {
-            this.get('flashMessages').add({
-              message: messages.socialAuthSignup,
-              type: 'success',
-              sticky: true,
-            });
-          });
-        }
-      })
-      .catch(() => {
-        next(() => {
-          this.get('flashMessages').add({
-            message: messages.socialAuthCancelled,
-            type: 'warning',
-            sticky: true,
-          });
-        });
-      });
+      get(this, 'session').authenticate('authenticator:torii', 'facebook-connect')
+      .catch(() => this.onFacebookLoginFailure());
     }
+  },
+  onFacebookLoginFailure() {
+    // because we clear flash messages when clicking this form,
+    // wait a tick when we add one in an action that can
+    // be triggered with a click
+    next(() => {
+      this.get('flashMessages').add({
+        message: messages.socialAuthCancelled,
+        type: 'warning',
+        sticky: true,
+      });
+    });
   },
   signUp() {
     return get(this, 'newUser').save();

--- a/addon/components/nypr-accounts/password-card.js
+++ b/addon/components/nypr-accounts/password-card.js
@@ -29,7 +29,6 @@ export default Ember.Component.extend({
               this.set('isEditing', false);
             })
             .catch((e) => {
-              console.log(e);
               if (e && get(e, 'errors.message')) {
                 changeset.pushErrors('currentPassword', e.errors.message);
               } else {

--- a/addon/templates/components/nypr-account-forms/login.hbs
+++ b/addon/templates/components/nypr-account-forms/login.hbs
@@ -20,7 +20,7 @@
     <h2 class="account-form-heading">Log in to {{siteName}}</h2>
     {{#if showSocialLogin}}
       <button type="button" class="account-form-btn account-form-btn--facebook"  {{action 'loginWithFacebook'}}>
-        <i class="fa fa-facebook-square"></i>Log in with Facebook
+        <i class="fa fa-facebook-official"></i>Log in with Facebook
       </button>
 
       <div class="account-form-separator">or</div>

--- a/addon/templates/components/nypr-account-forms/reset.hbs
+++ b/addon/templates/components/nypr-account-forms/reset.hbs
@@ -4,9 +4,6 @@
     showSocialLogin=false
     authAPI=authAPI
     session=session}}
-    {{#each flashMessages.queue as |flash|}}
-      {{flash-message flash=flash}}
-    {{/each}}
   {{/nypr-account-forms/login}}
 
 {{else}}

--- a/addon/templates/components/nypr-account-forms/signup.hbs
+++ b/addon/templates/components/nypr-account-forms/signup.hbs
@@ -12,7 +12,7 @@
 
   <h2 class="account-form-heading">Sign up for an account</h2>
 
-  {{#if showSocialLogin}}
+  {{#if showSocialSignup}}
     <button type="button" class="account-form-btn account-form-btn--facebook" {{action 'signupWithFacebook'}}>
       <i class="fa fa-facebook-square"></i>Sign up with Facebook
     </button>

--- a/addon/templates/components/nypr-account-forms/signup.hbs
+++ b/addon/templates/components/nypr-account-forms/signup.hbs
@@ -14,7 +14,7 @@
 
   {{#if showSocialSignup}}
     <button type="button" class="account-form-btn account-form-btn--facebook" {{action 'signupWithFacebook'}}>
-      <i class="fa fa-facebook-square"></i>Sign up with Facebook
+      <i class="fa fa-facebook-official"></i>Sign up with Facebook
     </button>
 
     <div class="account-form-separator">or</div>

--- a/addon/templates/components/nypr-account-forms/signup.hbs
+++ b/addon/templates/components/nypr-account-forms/signup.hbs
@@ -10,7 +10,9 @@
     {{nypr-account-forms/thanks email=changeset.email}}
   {{else}}
 
-  {{#if showSocialSignup}}
+  <h2 class="account-form-heading">Sign up for an account</h2>
+
+  {{#if showSocialLogin}}
     <button type="button" class="account-form-btn account-form-btn--facebook" {{action 'signupWithFacebook'}}>
       <i class="fa fa-facebook-square"></i>Sign up with Facebook
     </button>

--- a/addon/templates/components/nypr-account-forms/validate.hbs
+++ b/addon/templates/components/nypr-account-forms/validate.hbs
@@ -5,9 +5,6 @@
     showSocialLogin=false
     authAPI=authAPI
     session=session}}
-    {{#each flashMessages.queue as |flash|}}
-      {{flash-message flash=flash}}
-    {{/each}}
   {{/nypr-account-forms/login}}
 
 {{else}}

--- a/addon/validations/nypr-accounts/custom-messages.js
+++ b/addon/validations/nypr-accounts/custom-messages.js
@@ -16,6 +16,5 @@ export default {
   emailNotFound:         email => `we can't find an account for the email ${email}. <a href="/signup">Sign up?</a>`,
   publicHandleRequired:  'public handle cannot be blank',
   publicHandleExists:    'public handle already exists',
-  socialAuthCancelled:   "Unfortunately, we weren't able to authorize your account.",
-  socialAuthSignup:      "You’re now logged in via Facebook. You can update your information on your account page.",
+  socialAuthCancelled:   "We're sorry, but we weren't able to log you in through Facebook.",
 };

--- a/addon/validations/nypr-accounts/custom-messages.js
+++ b/addon/validations/nypr-accounts/custom-messages.js
@@ -16,4 +16,6 @@ export default {
   emailNotFound:         email => `we can't find an account for the email ${email}. <a href="/signup">Sign up?</a>`,
   publicHandleRequired:  'public handle cannot be blank',
   publicHandleExists:    'public handle already exists',
+  socialAuthCancelled:   "Unfortunately, we weren't able to authorize your account.",
+  socialAuthSignup:      "You’re now logged in via Facebook. You can update your information on your account page.",
 };

--- a/tests/integration/components/nypr-account-forms/validate-test.js
+++ b/tests/integration/components/nypr-account-forms/validate-test.js
@@ -45,7 +45,7 @@ test('it sends the correct values to the endpoint to verify the account', functi
   });
 });
 
-test('it shows the login form and success alert when verification succeeds', function(assert) {
+test('it shows the login form when verification succeeds', function(assert) {
   const testUser = 'UserName';
   const testConfirmation = 'QWERTYUIOP';
   let authAPI = 'http://example.com';
@@ -65,7 +65,6 @@ test('it shows the login form and success alert when verification succeeds', fun
   return wait().then(() => {
     assert.equal(this.$('.account-form').length, 1, 'it should show an account form');
     assert.equal(this.$('button:contains(Log in)').length, 1, 'it should show a login button');
-    assert.equal(this.$('.alert-success:contains(Your email has been verified and your online account is now active.)').length, 1, 'it should show a success alert');
   });
 });
 


### PR DESCRIPTION
Moves details of social user model creation out of signup method.
Adds flash messages for social signup failure and success.
Moves display of flash messages out of individual forms.

https://jira.wnyc.org/browse/WE-6588
https://jira.wnyc.org/browse/WE-6869