### PR TITLE
don't need our fork of ember-modal dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-changeset": "1.2.0",
     "ember-changeset-validations": "1.2.4",
     "ember-cli-compass-compiler": "^0.5.0",
-    "ember-modal-dialog": "nypublicradio/ember-modal-dialog"
+    "ember-modal-dialog": "0.9.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
release with
nypublicradio/wnyc-web-client#101
nypublicradio/publisher#70
nypublicradio/wqxr-web-client#45