### PR TITLE
Use HTML forms so users can submit with enter

### DIFF
--- a/addon/templates/components/nypr-accounts/basic-card.hbs
+++ b/addon/templates/components/nypr-accounts/basic-card.hbs
@@ -7,7 +7,8 @@
       click=(action 'toggleEdit')
       text=(if isEditing 'Cancel' 'Edit')}}
   {{/card.header}}
-  
+
+  <form disabled={{not isEditing}} {{action 'save' changeset on='submit'}}>
   {{#unless isEditing}}
     {{nypr-input
       label='Name'
@@ -69,19 +70,22 @@
       <button
         class="nypr-account-cancel"
         data-test-selector="rollback"
+        type="button"
         {{action 'rollback' changeset}}>Cancel</button>
 
       <button
         class="nypr-account-confirm"
         data-test-selector="save"
-        {{action 'save' changeset}}>Save</button>
+        type="submit">Save</button>
     </div>
   </div>
   {{/if}}
+  </form>
 {{/nypr-card}}
 
 {{#if isShowingModal}}
   {{#nypr-account-modal title="Re-enter Your Password" closeAction=(action 'closeModal') as |m|}}
+    <form {{action 'verifyPassword' on='submit'}}>
     {{#m.body}}
     <p>
       You must re-enter your password to make changes to your email. The email you are changing is the one you use to log into the site.
@@ -103,7 +107,8 @@
       <button
         class="nypr-account-confirm"
         data-test-selector="check-pw"
-        {{action 'verifyPassword'}}>Submit</button>
+        >Submit</button>
     {{/m.footer}}
+    </form>
   {{/nypr-account-modal}}
 {{/if}}

--- a/addon/templates/components/nypr-accounts/password-card.hbs
+++ b/addon/templates/components/nypr-accounts/password-card.hbs
@@ -8,6 +8,7 @@
       text=(if isEditing 'Cancel' 'Edit')}}
   {{/card.header}}
 
+  <form disabled={{not isEditing}} {{action 'save' changeset on='submit'}}>
   {{#unless isEditing}}
     {{nypr-input
       label='Password'
@@ -43,13 +44,15 @@
       <button
         class="nypr-account-cancel"
         data-test-selector="rollback"
+        type="button"
         {{action 'rollback' changeset}}>Cancel</button>
-        
+
       <button
         class="nypr-account-confirm"
         data-test-selector="save"
-        {{action 'save' changeset}}>Save</button>
+        type="submit">Save</button>
     </div>
   </div>
   {{/if}}
+  </form>
 {{/nypr-card}}


### PR DESCRIPTION
A few cards were essentially forms but without an enclosing form element they relied on the button action to work.

Using proper HTML forms and updating on the submit action of the form instead of the button action is an accessibility improvement that allows users to submit the form with their enter key.

This fixes [WE-7189](https://jira.wnyc.org/browse/WE-7189) and [WE-7190](https://jira.wnyc.org/browse/WE-7190).

I considered using an `nypr-form` component instead but I don't think we gain anything from it here right now.