### PR TITLE
Generate correct 'pledge update' links for each pledge fund

### DIFF
--- a/addon/templates/components/nypr-accounts/membership-card/current-status-detail.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card/current-status-detail.hbs
@@ -30,7 +30,7 @@ Possible user states to handle:
         </div>
       </div>
       <div class="pledge-update-link">
-        <a href="https://{{pledgePrefix}}.{{siteDomain}}.org/donate/mc-{{lowercase pledge.fund}}/sustainer/?order_id={{pledge.orderKey}}">Update</a>
+        <a href="{{pledge.updateLink}}/{{pledge.orderType}}/">Update</a>
       </div>
     </div>
   {{/each}}

--- a/tests/dummy/app/models/pledge.js
+++ b/tests/dummy/app/models/pledge.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import computed from 'ember-computed';
 
 const { Model, attr } = DS;
 
@@ -13,5 +14,10 @@ export default Model.extend({
   creditCardType: attr('string'),
   creditCardLast4Digits: attr('string'),
   isActiveMember: attr('boolean'),
-  isSustainer: attr('boolean')
+  isSustainer: attr('boolean'),
+  updateLink: computed('fund', function() {
+    let pledgeDomain = this.get('fund') === 'WQXR' ? 'wqxr' : 'wnyc';
+    let fundSlug = this.get('fund').toLowerCase().replace(/[\.\ ]/g, '');
+    return `https://pledge3.${pledgeDomain}.org/donate/mc-${fundSlug}`;
+  })
 });

--- a/tests/dummy/mirage/factories/pledge.js
+++ b/tests/dummy/mirage/factories/pledge.js
@@ -1,7 +1,7 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  fund: () => faker.random.arrayElement(["WNYC", "WQXR", "Radiolab"]),
+  fund: () => faker.random.arrayElement(["WNYC", "WQXR", "Radiolab", "J.Schwartz"]),
   orderPrice: () => faker.random.arrayElement([60, 72, 120, 12, 90, 100]),
   orderDate: faker.date.past,
   orderCode: () => faker.random.arrayElement([1234567,2345678,3456789]),

--- a/tests/unit/models/pledge-test.js
+++ b/tests/unit/models/pledge-test.js
@@ -1,0 +1,39 @@
+import { moduleForModel, test } from "ember-qunit";
+import Ember from 'ember';
+
+moduleForModel("pledge", "Unit | Model | pledge", {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test("it exists", function(assert) {
+  let model = this.subject();
+
+  Ember.run(function() {
+    model.set("fund", "WNYC");
+    assert.equal(
+      model.get("updateLink"),
+      "https://pledge3.wnyc.org/donate/mc-wnyc"
+    );
+    model.set("fund", "WQXR");
+    assert.equal(
+      model.get("updateLink"),
+      "https://pledge3.wqxr.org/donate/mc-wqxr"
+    );
+    model.set("fund", "Radiolab");
+    assert.equal(
+      model.get("updateLink"),
+      "https://pledge3.wnyc.org/donate/mc-radiolab"
+    );
+    model.set("fund", "Freakonomics");
+    assert.equal(
+      model.get("updateLink"),
+      "https://pledge3.wnyc.org/donate/mc-freakonomics"
+    );
+    model.set("fund", "J. Schwartz");
+    assert.equal(
+      model.get("updateLink"),
+      "https://pledge3.wnyc.org/donate/mc-jschwartz"
+    );
+  });
+});


### PR DESCRIPTION
This adds a computed property on the pledge model in the dummy app to compile the proper update link for sustaining pledges. The rules are pretty simple

- All funds except WQXR should be in the pledge3.wnyc.org domain, and the campaign should fit the pattern `mc-{fund}`
- WQXR will point to pledge3.wqxr.org, and will use the campaign `mc-wqxr`