### PR TITLE
WE-7411 modal issues

### DIFF
--- a/addon/components/nypr-accounts/basic-card.js
+++ b/addon/components/nypr-accounts/basic-card.js
@@ -182,9 +182,11 @@ export default Component.extend({
   }).drop(),
 
   promptForPassword: task(function * () {
+    Ember.$('body').addClass('has-nypr-account-modal-open');
     try {
       yield waitForEvent(this, 'passwordVerified');
     } finally {
+      Ember.$('body').removeClass('has-nypr-account-modal-open');
       set(this, 'password', null);
     }
   }).drop(),

--- a/app/styles/_nypr-account-modal.scss
+++ b/app/styles/_nypr-account-modal.scss
@@ -52,3 +52,7 @@
   width: 15px;
   height: 15px;
 }
+
+body.has-nypr-account-modal-open {
+  overflow: hidden;
+}

--- a/app/styles/_nypr-account-modal.scss
+++ b/app/styles/_nypr-account-modal.scss
@@ -8,6 +8,7 @@
 .nypr-account-overlay.ember-modal-overlay {
   z-index: $zIndex--modal;
   background-color: rgba(0,0,0,0.8);
+  height: 100%;
 }
 
 .nypr-account-modal-title {


### PR DESCRIPTION
This change fixes the translucent modal overlay disappearing when you activate the keyboard on iOS < 10.3.
It also prevents the background from scrolling behind the modal in some browsers, but notably, not IOS.