### PR TITLE
Fix failing builds

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,6 +36,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:each",
-    "upgrade-nypr": "yarn upgrade nypr-ui"
+    "upgrade-nypr": "yarn upgrade nypublicradio/nypr-ui"
   },
   "dependencies": {
     "ember-changeset": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4646,7 +4646,7 @@ number-is-nan@^1.0.0:
 
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/853d67dcfe115fcfb9fffc9cb4e6d6fbfaa14a6b"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/df551a56435a8f1d426edc57ba131b633f6e7484"
   dependencies:
     ember-cli-babel "^5.1.7"
     ember-cli-compass-compiler "^0.5.0"


### PR DESCRIPTION
- Fix `upgrade-nypr` command to point to our nypublicradio repository.
- Allow ember canary tests to fail. They're something worth keeping an eye on but I don't think we should put too much energy into debugging code that might not even make it to beta.