### PR TITLE
UI Tweaks

### DIFF
--- a/addon/templates/components/nypr-accounts/membership-card.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card.hbs
@@ -48,7 +48,7 @@
 
   {{#m.panel to=0 title="Giving History" as |card|}}
     {{#card.header class="giving-history-header" as |header|}}
-      {{card.button text="Back" class="nypr-card-edit-btn pledge-payment-history-back-button"}}
+      {{card.button text="< Back" class="nypr-card-edit-btn pledge-payment-history-back-button"}}
       {{header.title class="giving-history-title"}}
     {{/card.header}}
     {{nypr-accounts/membership-card/giving-history

--- a/addon/templates/components/nypr-accounts/membership-card/donation-button.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card/donation-button.hbs
@@ -1,10 +1,10 @@
 {{#if orderKey}}
-<a class="pledge-donate-button" href="https://{{pledgePrefix}}.{{siteDomain}}.org/donate/membership-sustainer/sustainer/?order_id={{orderKey}}" target="_blank">
-  {{yield}}
-</a>
+  <a class="pledge-donate-button {{siteDomain}}-pledge-donate-button" href="https://{{pledgePrefix}}.{{siteDomain}}.org/donate/membership-sustainer/sustainer/?order_id={{orderKey}}" target="_blank">
+    {{yield}}
+  </a>
 {{else}}
-<a class="pledge-donate-button" href="https://{{pledgePrefix}}.{{siteDomain}}.org/donate/mc-main/" target="_blank">
-  {{yield}}
-</a>
+  <a class="pledge-donate-button {{siteDomain}}-pledge-donate-button" href="https://{{pledgePrefix}}.{{siteDomain}}.org/donate/mc-main/" target="_blank">
+    {{yield}}
+  </a>
 {{/if}}
 

--- a/app/styles/_nypr-account-modal.scss
+++ b/app/styles/_nypr-account-modal.scss
@@ -5,7 +5,7 @@
   max-width: 457px;
 }
 
-.nypr-account-overlay.ember-modal-overlay {
+.nypr-account-wrapper .nypr-account-overlay.ember-modal-overlay {
   z-index: $zIndex--modal;
   background-color: rgba(0,0,0,0.8);
   height: 100%;

--- a/app/styles/lib/_mixins.scss
+++ b/app/styles/lib/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin small-gray-font {
-  font-size: 12px;
+  font-size: 14px;
   color: #888;
   font-weight: 400;
   font-family: $base-font-stack;

--- a/app/styles/nypr-member-center.scss
+++ b/app/styles/nypr-member-center.scss
@@ -38,12 +38,12 @@
 }
 
 .active-donations-header,
-.pledge-order-price,
 .pledge-update-link,
 .pledge-payment-history,
 .pledge-tax-receipt,
 .pledge-order-cc-type,
 .pledge-help-link,
+.pledge-info-container .pledge-order-price,
 .pledge-hyphen-separator {
   @include small-gray-font;
 }

--- a/app/styles/nypr-member-center.scss
+++ b/app/styles/nypr-member-center.scss
@@ -64,6 +64,8 @@
 
 .pledge-tools {
   @include justify-content(flex-end);
+
+  margin-top: 50px;
 }
 
 .pledge-order-info {

--- a/app/styles/nypr-member-center.scss
+++ b/app/styles/nypr-member-center.scss
@@ -53,7 +53,7 @@
 }
 
 .pledge-container {
-  border-bottom: 1px solid #f1f1f1;
+  border-bottom: 1px solid $lightestgray;
   margin-bottom: 1rem;
 }
 

--- a/app/styles/nypr-member-center/_current-status-detail.scss
+++ b/app/styles/nypr-member-center/_current-status-detail.scss
@@ -27,8 +27,15 @@
 }
 
 .wqxr-pledge-donate-button {
-  background-color: #2064b4;
-  border-color: #2064b4;
+  $wqxr-blue: #2064b4;
+
+  background-color: $wqxr-blue;
+  border-color: $wqxr-blue;
+
+  &:not([disabled]):hover {
+    background-color: darken($wqxr-blue, 10%);
+    border-color: darken($wqxr-blue, 10%);
+  }
 }
 
 .last-pledge-date {

--- a/app/styles/nypr-member-center/_current-status-detail.scss
+++ b/app/styles/nypr-member-center/_current-status-detail.scss
@@ -19,7 +19,10 @@
   @include btn;
   @include btn--red;
 
+  font-size: 16px;
+  font-weight: 600;
   margin-top: 0;
+  padding: 4px 16px;
   text-decoration: none;
 }
 

--- a/app/styles/nypr-member-center/_current-status-detail.scss
+++ b/app/styles/nypr-member-center/_current-status-detail.scss
@@ -26,6 +26,11 @@
   text-decoration: none;
 }
 
+.wqxr-pledge-donate-button {
+  background-color: #2064b4;
+  border-color: #2064b4;
+}
+
 .last-pledge-date {
   color: $darkergray;
   font-size: $base-font * 0.875 + px;

--- a/app/styles/nypr-member-center/_giving-history.scss
+++ b/app/styles/nypr-member-center/_giving-history.scss
@@ -4,6 +4,11 @@
 
 .pledge-payment-history-back-button {
   width: 100px;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  color: #888888;
+  text-transform: uppercase;
 }
 
 .giving-history-header > span {

--- a/app/styles/nypr-member-center/_giving-history.scss
+++ b/app/styles/nypr-member-center/_giving-history.scss
@@ -28,7 +28,7 @@
 
   margin-left: -4px;
   margin-right: -4px;
-  padding-bottom: 10px;
+  padding-bottom: 1rem;
 
   div {
     margin-left: 4px;

--- a/app/styles/nypr-member-center/_giving-history.scss
+++ b/app/styles/nypr-member-center/_giving-history.scss
@@ -49,6 +49,7 @@
   border: none;
   background: none;
   cursor: pointer;
+  padding-right: 12px;
 }
 
 .giving-history-limit-notification {

--- a/app/styles/nypr-member-center/_giving-history.scss
+++ b/app/styles/nypr-member-center/_giving-history.scss
@@ -56,3 +56,13 @@
 
   font-style: italic;
 }
+
+.nypr-membership-info-body .nypr-tabs .nypr-tabs-tablist {
+  .ivy-tabs-tab {
+    border-color: $lightestgray;
+  }
+
+  .tablist-buffer {
+    border-bottom: 1px solid $lightestgray;
+  }
+}


### PR DESCRIPTION
# High prio
- [x] Button color should be blue on WQXR, red on WNYC a2e4956
- [x] Button should be larger and heavier weight font (zeplin mockup: 16px font, 600 font weight, 46px button height). 01a5d119f65961566a0469f4b6caee1ae1234850
- [x] Any 12px font-size, change it up to 14px (footer links, gifts, and tabs) – same thing on mobile ee04998606d930ef0e46d03fdc355c7aa5f4a121 https://github.com/nypublicradio/nypr-ui/pull/59/commits/8192ae11f7847b42814388f306f5113e3ed50899
- [x] Rules / borders: set them to #ddd: lines and tabs ed64bfa3710bfa12f2783409166a2a40213da5e5
- [x] In donation history, amount should be #333 and should be the same size as the rest of what's on the same line (16px) 302af2c9a047ec75a6aa63b661c34ae1c0577e44
- [x] Once you click 'payment history' and go to that view, the back button is styled incorrectly - should be on the left with the arrow icon and should be grey (see zeplin) 3df64f0a374f4ff9ff442383542641e0099dce84
- [x] Tabs increase flex to 0 1 170px https://github.com/nypublicradio/nypr-ui/pull/59/commits/8192ae11f7847b42814388f306f5113e3ed50899
- [ ] Help overlay - Width of window needs to be adjusted
- [x] Help overlay - Background of the page needs to be darker to match designs 31364c24c499bcd02527556965fde75fa9f681c8
- [ ] Help overlay - Remove Dropshadow
- [ ] Help overlay - Rounded corners set to 3px
- [ ] Help overlay - gray header needs to touch edges 
- [x] Padding above the row of links that include payment history and help should match zeplin mockup. 7893bb2
- [x] in payment history view, the donation amount is small and grey but it should be #333 and 16px 302af2c9a047ec75a6aa63b661c34ae1c0577e44
- [x] Need to space giving history / help links by 20px d206e18c3fffd8853a7ba1a6623979188fff4bec
- [x] Bottom padding on the rows needs to be same as top padding e7240f9
- [ ] Footer -Wondering if we can all make them look the same (gray with underline), also something seems off with the underline one (too much padding?) I would look at what we're doing on the story page in comparison. Maybe the line-height is too great.
- [x] in payment history view, the content between the grey lines should be vertically centered (right now in cases where there's a second line showing gift amount, there's more padding above than below) e7240f9

# Lower prio (could happen right after launch, still needs to happen though 😊)
- [ ] Could we reduce the size of the spinning animation in half
- [ ] There's a little too much padding below 'active recurring donations' and the donation. Also slightly too much below the donation title and the payment amount. Should match zeplin mockup.
- [ ] Email is missing from below the payment amount
- [ ] hover state on button shows a weird underline behind the button
- [ ] Hover state on 'payment history' and 'help' should be grey (to match the text) - currently it's blue. [MB: I'm confused about this one]
