### PR TITLE
Add margin to modal dialog box

### DIFF
--- a/addon/templates/components/nypr-account-modal.hbs
+++ b/addon/templates/components/nypr-account-modal.hbs
@@ -2,20 +2,22 @@
   close=closeAction
   clickOutsideToClose=true
   wrapper-class="nypr-account-wrapper"
-  container-class="nypr-account-container"
+  container-class="nypr-account-container-outer"
   overlay-class="nypr-account-overlay"
   translucentOverlay=true
   targetAttachment="center"}}
+  <div class="nypr-account-container-inner">
   {{#if title}}
   <div class="nypr-account-modal-title">
     <span>{{title}}</span>
-    
+
     <button class="nypr-account-modal-close" {{action closeAction}}>{{nypr-svg icon='close'}}</button>
   </div>
   {{/if}}
-  
+
   {{yield (hash
     body=(component 'nypr-account-modal/body')
     footer=(component 'nypr-account-modal/footer')
   )}}
+  </div>
 {{/modal-dialog}}

--- a/app/styles/_nypr-account-modal.scss
+++ b/app/styles/_nypr-account-modal.scss
@@ -1,8 +1,15 @@
-.nypr-account-container {
+.nypr-account-container-outer {
+  padding: 15px;
+  max-width: 457px;
+  background-color: transparent;
+}
+
+.nypr-account-container-inner {
   padding: 0;
   border-radius: 3px;
   overflow: hidden;
-  max-width: 457px;
+  background-color: white;
+  box-shadow: 0 0 10px #222;
 }
 
 .nypr-account-wrapper .nypr-account-overlay.ember-modal-overlay {

--- a/app/styles/nypr-account-modal.scss
+++ b/app/styles/nypr-account-modal.scss
@@ -1,7 +1,18 @@
+@import "compass/css3/flexbox";
+
+@import "ember-modal-dialog/ember-modal-structure";
+@import "ember-modal-dialog/ember-modal-appearance";
+
+@import "nypr-ui/vars";
+@import "nypr-ui/colors";
+@import "nypr-ui/z-index";
+@import "nypr-ui/buttons";
+
 .nypr-account-container-outer {
   padding: 15px;
   max-width: 457px;
   background-color: transparent;
+  box-shadow: none;
 }
 
 .nypr-account-container-inner {

--- a/app/styles/nypr-account-settings.scss
+++ b/app/styles/nypr-account-settings.scss
@@ -1,14 +1,9 @@
 @import "compass/css3/flexbox";
 
-@import "ember-modal-dialog/ember-modal-structure";
-@import "ember-modal-dialog/ember-modal-appearance";
-
 @import "nypr-ui/vars";
 @import "nypr-ui/colors";
 @import "nypr-ui/z-index";
 @import "nypr-ui/buttons";
-
-@import "nypr-account-modal";
 
 .nypr-account-settings-and-member-center {
   @include display-flex();
@@ -251,17 +246,17 @@
   margin: 0;
   @include fontsize(12);
   line-height: 1.5;
-  
+
   @media screen and (min-width: 960px) {
     @include fontsize(14);
   }
-  
+
   > a {
     text-decoration: none;
     color: $blue;
     border-bottom: 1px solid rgba($blue, 0);
     transition: 125ms ease border-bottom-color;
-    
+
     &:hover {
       border-bottom-color: $blue;
     }

--- a/app/styles/nypr-member-center.scss
+++ b/app/styles/nypr-member-center.scss
@@ -13,6 +13,8 @@
 @import "nypr-member-center/current-status-detail";
 @import "nypr-member-center/loading-animation";
 
+@import "nypr-account-modal";
+
 .pledge-container,
 .pledge-info,
 .pledge-tools {

--- a/app/styles/nypr-member-center.scss
+++ b/app/styles/nypr-member-center.scss
@@ -1,8 +1,5 @@
 @import "compass/css3/flexbox";
 
-@import "ember-modal-dialog/ember-modal-structure";
-@import "ember-modal-dialog/ember-modal-appearance";
-
 @import "nypr-ui/vars";
 @import "nypr-ui/colors";
 @import "nypr-ui/z-index";
@@ -12,8 +9,6 @@
 @import "nypr-member-center/giving-history";
 @import "nypr-member-center/current-status-detail";
 @import "nypr-member-center/loading-animation";
-
-@import "nypr-account-modal";
 
 .pledge-container,
 .pledge-info,

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -16,4 +16,5 @@ body {
 @import "nypr-ui";
 @import "nypr-account-settings";
 @import "nypr-member-center";
+@import "nypr-account-modal";
 @import "layout";


### PR DESCRIPTION
`nypr-account-container` is dynamically positioned by ember-modal-dialog, so we can't just offset in css to account for margins. Safer to just add another container div and apply the styles there.

https://jira.wnyc.org/browse/WE-7287