### PR TITLE
WE-7510 Adjust breakpoint for hiding the handle description text

### DIFF
--- a/app/styles/nypr-account-settings.scss
+++ b/app/styles/nypr-account-settings.scss
@@ -57,7 +57,7 @@
 }
 
 .nypr-input-label[for="preferredUsername"] > span {
-  @media only screen and (max-width: 378px) {
+  @media only screen and (max-width: 435px) {
     display: none;
   }
 }


### PR DESCRIPTION
We want to just hide the  parenthetical part of the *"Public Handle (visible when you comment on the site)"* message when the page is too narrow to show it on a single line

https://jira.wnyc.org/browse/WE-7510