### PR TITLE
WE-7239 Move error for non-existent email

### DIFF
--- a/addon/components/nypr-account-forms/login.js
+++ b/addon/components/nypr-account-forms/login.js
@@ -53,6 +53,9 @@ export default Component.extend({
           case 'UserNoPassword':
             set(this, 'loginError', messages.noPasswordLoginError);
             break;
+          case 'UserNotFoundException':
+            set(this, 'loginError', messages.emailNotFound( get(this, 'changeset.email') ));
+            break;
           default:
             this.applyErrorToChangeset(e.errors, get(this, 'changeset'));
         }
@@ -99,9 +102,6 @@ export default Component.extend({
       changeset.rollback(); // so errors don't stack up
       if (error.message === 'User is disabled') {
         changeset.pushErrors('email', messages.userDisabled);
-      } else if (error.code === "UserNotFoundException") {
-        changeset.validate('email');
-        changeset.pushErrors('password', messages.emailNotFound( changeset.get('email') ));
       }
     }
   }

--- a/addon/validations/nypr-accounts/custom-messages.js
+++ b/addon/validations/nypr-accounts/custom-messages.js
@@ -14,7 +14,7 @@ export default {
   userDisabled:          'This email is associated with a disabled account. If you would like to re-enable it, please contact listener services at <a href="http://www.wnyc.org/feedback" target="_blank">http://www.wnyc.org/feedback</a>.',
   genericLoginError:     "There's an error logging in.</br><a href='/forgot'>Forget your password</a>? Need to <a href='/signup'>create an account</a>?",
   noPasswordLoginError:  "It looks like you previously signed up through Facebook. You can log in via the Facebook button above or <a href='/signup'>sign up for an account</a> using this email.",
-  emailNotFound:         email => `we can't find an account for the email ${email}. <a href="/signup">Sign up?</a>`,
+  emailNotFound:         email => `We can't find an account for the email ${email}.</br>Need to <a href='/signup'>create an account</a>?`,
   publicHandleRequired:  'public handle cannot be blank',
   publicHandleExists:    'public handle already exists',
   emailExists:           'an account with this email address already exists',


### PR DESCRIPTION
Move error for non-existent email to the form-level error area instead of attaching it to the email input.

https://jira.wnyc.org/browse/WE-7239
