### PR TITLE
claim email with member center when setting a password

### DIFF
--- a/addon/components/nypr-account-forms/set-password.js
+++ b/addon/components/nypr-account-forms/set-password.js
@@ -1,6 +1,6 @@
 import layout from '../../templates/components/nypr-account-forms/set-password';
 import Component from 'ember-component';
-import get from 'ember-metal/get';
+import get, { getProperties } from 'ember-metal/get';
 import set from 'ember-metal/set';
 import computed from 'ember-computed';
 import service from 'ember-service/inject';
@@ -33,7 +33,7 @@ export default Component.extend({
     let url = `${get(this, 'authAPI')}/v1/password/change-temp`;
     let method = 'POST';
     let headers = { "Content-Type" : "application/json" };
-    let body = JSON.stringify({username, email, temp, "new": newPassword});
+    let body = JSON.stringify({username, email, temp, new: newPassword});
     let response = yield fetch(url, {method, headers, body});
     if (!response || response && !response.ok) {
       throw yield response.json();
@@ -61,10 +61,18 @@ export default Component.extend({
   
   doSubmit: task(function * () {
     let changeset = get(this, 'changeset');
+    let {
+      username,
+      email,
+      code,
+      'fields.password':password,
+      emailId,
+      verificationToken
+    } = getProperties(this, 'username', 'email', 'code', 'fields.password', 'emailId', 'verificationToken');
     try {
       return yield all([
-        get(this, 'setPassword').perform(get(this, 'username'), get(this, 'email'), get(this, 'code'), get(this, 'fields.password')),
-        get(this, 'claimEmail').perform(get(this, 'emailId'), get(this, 'verificationToken'))
+        get(this, 'setPassword').perform(username, email, code, password),
+        get(this, 'claimEmail').perform(emailId, verificationToken)
       ]);
     } catch(error) {
       if (get(error, 'errors.code') === 'UnauthorizedAccess') {

--- a/addon/components/nypr-account-forms/set-password.js
+++ b/addon/components/nypr-account-forms/set-password.js
@@ -82,7 +82,7 @@ export default Component.extend({
   
   actions: {
     onSubmit() {
-      return this.setPassword(get(this, 'username'), get(this, 'email'), get(this, 'code'), get(this, 'fields.password'));
+      return get(this, 'doSubmit').perform();
     },
     onSuccess() {
       this.set('passwordWasSet', true);

--- a/addon/components/nypr-account-forms/set-password.js
+++ b/addon/components/nypr-account-forms/set-password.js
@@ -39,6 +39,26 @@ export default Component.extend({
       throw yield response.json();
     }
   }),
+  claimEmail: task(function * (emailId, token) {
+    let url = `${get(this, 'membershipAPI')}/v1/emails/${emailId}/verify/`;
+    let method = 'PATCH';
+    let body = JSON.stringify({ data: {
+      id: Number(emailId),
+      type: "EmailAddress",
+      attributes: {
+        "verification_token": token
+      }
+    }});
+    let headers = {'Content-Type': 'application/vnd.api+json'};
+    this.get('session').authorize('authorizer:nypr', (header, value) => {
+      headers[header] = value;
+    });
+    let response = yield fetch(url, {method, headers, body});
+    if (!response || response && !response.ok) {
+      throw yield response.json();
+    }
+  }),
+  
     let changeset = get(this, 'changeset');
     return fetch(url, {method, headers, body})
     .then(rejectUnsuccessfulResponses)

--- a/tests/integration/components/nypr-account-forms/set-password-test.js
+++ b/tests/integration/components/nypr-account-forms/set-password-test.js
@@ -7,6 +7,7 @@ moduleForComponent('nypr-account-forms/set-password', 'Integration | Component |
   integration: true,
   beforeEach() {
     this.server = startMirage();
+    this.session = { authorize(_, cb) { cb('authorization', 'foo');} };
   },
   afterEach() {
     this.server.shutdown();
@@ -33,16 +34,41 @@ test('it shows the correct message', function(assert) {
 });
 
 test('submitting the form sends the correct values to the correct endpoint', function(assert) {
+  this.set('session', this.session);
+
+  // membership values
+  const testEmailId = '123';
+  const testVerification = 'QWERTYUIOP';
+  let membershipAPI = 'http://example.com';
+  this.set('emailId', testEmailId);
+  this.set('verificationToken', testVerification);
+  this.set('membershipAPI', membershipAPI);
+
+  // auth values
   this.set('authAPI', authAPI);
   this.set('username', testUsername);
   this.set('email', testEmail);
   this.set('code', testCode);
-  this.render(hbs`{{nypr-account-forms/set-password username=username email=email code=code authAPI=authAPI}}`);
+  this.render(hbs`{{nypr-account-forms/set-password
+    session=session
+    username=username
+    email=email
+    code=code
+    emailId=emailId
+    verificationToken=verificationToken
+    membershipAPI=membershipAPI
+    authAPI=authAPI}}`);
 
-  let requests = [];
-  let url = `${authAPI}/v1/password/change-temp`;
-  this.server.post(url, (schema, request) => {
-    requests.push(request);
+  let requests = {password: null, claimEmail: null};
+  let passwordUrl = `${authAPI}/v1/password/change-temp`;
+  this.server.post(passwordUrl, (schema, request) => {
+    requests.password = request;
+    return {};
+  }, 200);
+  
+  let claimEmailUrl = `${membershipAPI}/v1/emails/${testEmailId}/verify/`;
+  this.server.patch(claimEmailUrl, (schema, request) => {
+    requests.claimEmail = request;
     return {};
   }, 200);
   this.$('label:contains(New Password) + input').val(testPassword);
@@ -50,12 +76,32 @@ test('submitting the form sends the correct values to the correct endpoint', fun
   this.$('button:contains(Create password)').click();
 
   return wait().then(() => {
-    assert.equal(requests.length, 1);
-    assert.deepEqual(JSON.parse(requests[0].requestBody), {username: testUsername, email: testEmail, temp: testCode, new: testPassword});
+    assert.equal(Object.keys(requests).length, 2);
+    assert.deepEqual(JSON.parse(requests.password.requestBody), {username: testUsername, email: testEmail, temp: testCode, new: testPassword});
+    assert.deepEqual(JSON.parse(requests.claimEmail.requestBody),{
+      data: {
+        id: Number(testEmailId),
+        type: "EmailAddress",
+        attributes: {
+          "verification_token": testVerification
+        }
+      }
+    });
   });
 });
 
 test('submitting the form calls the afterSetPassword action', function(assert) {
+  this.set('session', this.session);
+
+  // membership values
+  const testEmailId = '123';
+  const testVerification = 'QWERTYUIOP';
+  let membershipAPI = 'http://example.com';
+  this.set('emailId', testEmailId);
+  this.set('verificationToken', testVerification);
+  this.set('membershipAPI', membershipAPI);
+
+  // auth values
   this.set('authAPI', authAPI);
   this.set('username', testUsername);
   this.set('email', testEmail);
@@ -63,10 +109,21 @@ test('submitting the form calls the afterSetPassword action', function(assert) {
   let afterSetPasswordCalls = 0;
   this.set('afterSetPassword', () => afterSetPasswordCalls++);
 
-  this.render(hbs`{{nypr-account-forms/set-password username=username email=email code=code authAPI=authAPI afterSetPassword=afterSetPassword}}`);
+  this.render(hbs`{{nypr-account-forms/set-password
+    session=session
+    username=username
+    email=email
+    code=code
+    emailId=emailId
+    verificationToken=verificationToken
+    membershipAPI=membershipAPI
+    authAPI=authAPI
+    afterSetPassword=afterSetPassword}}`);
 
-  let url = `${authAPI}/v1/password/change-temp`;
-  this.server.post(url, {}, 200);
+  let passwordUrl = `${authAPI}/v1/password/change-temp`;
+  this.server.post(passwordUrl, {}, 200);
+  let claimEmailUrl = `${membershipAPI}/v1/emails/${testEmailId}/verify/`;
+  this.server.patch(claimEmailUrl, {}, 200);
   this.$('label:contains(New Password) + input').val(testPassword);
   this.$('label:contains(New Password) + input').blur();
   this.$('button:contains(Create password)').click();
@@ -78,15 +135,33 @@ test('submitting the form calls the afterSetPassword action', function(assert) {
 
 
 test("it shows the 'oops' page when api returns an unauthorized error", function(assert) {
+  this.set('session', this.session);
+
+  // membership values
+  const testEmailId = '123';
+  const testVerification = 'QWERTYUIOP';
+  let membershipAPI = 'http://example.com';
+  this.set('emailId', testEmailId);
+  this.set('verificationToken', testVerification);
+  this.set('membershipAPI', membershipAPI);
+
+  // auth values
   this.set('authAPI', authAPI);
   this.set('username', testUsername);
   this.set('code', testCode);
-  this.render(hbs`{{nypr-account-forms/set-password username=username code=code authAPI=authAPI}}`);
+  this.render(hbs`{{nypr-account-forms/set-password
+    session=session
+    username=username
+    code=code
+    emailId=emailId
+    verificationToken=verificationToken
+    membershipAPI=membershipAPI
+    authAPI=authAPI}}`);
 
-  let requests = [];
-  let url = `${authAPI}/v1/password/change-temp`;
-  this.server.post(url, (schema, request) => {
-    requests.push(request);
+  let requests = 0;
+  let passwordUrl = `${authAPI}/v1/password/change-temp`;
+  this.server.post(passwordUrl, () => {
+    requests++;
     return {
       "errors": {
         "code": "UnauthorizedAccess",
@@ -94,14 +169,15 @@ test("it shows the 'oops' page when api returns an unauthorized error", function
       }
     };
   }, 401);
+  let claimEmailUrl = `${membershipAPI}/v1/emails/${testEmailId}/verify/`;
+  this.server.patch(claimEmailUrl, () => requests++, 200);
 
   this.$('label:contains(New Password) + input').val(testPassword);
   this.$('label:contains(New Password) + input').blur();
   this.$('button:contains(Create password)').click();
 
   return wait().then(() => {
-    assert.equal(requests.length, 1, 'it should call the api set password url');
+    assert.equal(requests, 2, 'it should call the api set password url');
     assert.equal(this.$('.account-form-heading:contains(Oops!)').length, 1, 'the heading should say oops');
   });
 });
-


### PR DESCRIPTION
requires upstream updates to grab `verification_token` and `email_id` from the query params.

this also refactors the `set-password` component to use ember concurrency tasks.

[WE-7524](https://jira.wnyc.org/browse/WE-7524)