### PR TITLE
WE-7528 Tweak resend button for acceptance testing

### DIFF
--- a/addon/components/nypr-accounts/resend-button.js
+++ b/addon/components/nypr-accounts/resend-button.js
@@ -14,7 +14,7 @@ export default Ember.Component.extend({
   success: false,
   error: false,
   autoReset: true,
-  resetDelay: 10000,
+  resetDelay: Ember.testing ? 10 : 10000,
   successMessage: 'Email resent',
   errorMessage: 'Email not resent. Try again later',
   actions: {


### PR DESCRIPTION
A small tweak to the resend-button component to make it friendlier to acceptance tests