### PR TITLE
WE-6871 connect accounts

### DIFF
--- a/addon/components/nypr-accounts/social-card.js
+++ b/addon/components/nypr-accounts/social-card.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import layout from '../../templates/components/nypr-accounts/social-card';
+
+export default Ember.Component.extend({
+  layout
+});

--- a/addon/components/nypr-accounts/social-card.js
+++ b/addon/components/nypr-accounts/social-card.js
@@ -2,5 +2,6 @@ import Ember from 'ember';
 import layout from '../../templates/components/nypr-accounts/social-card';
 
 export default Ember.Component.extend({
-  layout
+  layout,
+  tagName: ''
 });

--- a/addon/components/nypr-accounts/social-connect-button.js
+++ b/addon/components/nypr-accounts/social-connect-button.js
@@ -2,5 +2,7 @@ import Ember from 'ember';
 import layout from '../../templates/components/nypr-accounts/social-connect-button';
 
 export default Ember.Component.extend({
-  layout
+  layout,
+  classNames: ['nypr-social-connect'],
+  buttonAction: () => {}
 });

--- a/addon/components/nypr-accounts/social-connect-button.js
+++ b/addon/components/nypr-accounts/social-connect-button.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import layout from '../../templates/components/nypr-accounts/social-connect-button';
+
+export default Ember.Component.extend({
+  layout
+});

--- a/addon/templates/components/nypr-accounts/social-card.hbs
+++ b/addon/templates/components/nypr-accounts/social-card.hbs
@@ -1,6 +1,6 @@
-{{#nypr-card class="nypr-social__card" as |card|}}
+{{#nypr-card class="nypr-social-card" as |card|}}
 
-  {{card.header class="nypr-social__header" title="Social"}}
+  {{card.header class="nypr-social-card__header" title="Social"}}
 
   {{yield (hash
     connect-button=(component 'nypr-accounts/social-connect-button')

--- a/addon/templates/components/nypr-accounts/social-card.hbs
+++ b/addon/templates/components/nypr-accounts/social-card.hbs
@@ -1,0 +1,9 @@
+{{#nypr-card class="nypr-social__card" as |card|}}
+
+  {{card.header class="nypr-social__header" title="Social"}}
+
+  {{yield (hash
+    connect-button=(component 'nypr-accounts/social-connect-button')
+  )}}
+
+{{/nypr-card}}

--- a/addon/templates/components/nypr-accounts/social-connect-button.hbs
+++ b/addon/templates/components/nypr-accounts/social-connect-button.hbs
@@ -1,6 +1,6 @@
 {{#if connected}}
 
-  <a class="nypr-social-connect__link" href={{manageUrl}} target="blank" rel="noopener noreferrer">Manage {{providerName}} connection</a>
+  <a class="nypr-social-connect__link" href={{manageUrl}} target="_blank" rel="noopener noreferrer">Manage {{providerName}} connection</a>
 
 {{else}}
 

--- a/addon/templates/components/nypr-accounts/social-connect-button.hbs
+++ b/addon/templates/components/nypr-accounts/social-connect-button.hbs
@@ -4,7 +4,10 @@
 
 {{else}}
 
-  <button class="nypr-social-connect__button {{buttonClass}}" {{action buttonAction}}>
+  <button
+    class="nypr-social-connect__button {{buttonClass}}"
+    data-test-selector="social-connect-{{providerName}}"
+    {{action buttonAction}}>
   {{#if providerIcon}}
     <i class="nypr-social-connect__icon fa fa-{{providerIcon}}"></i>
   {{/if}}

--- a/addon/templates/components/nypr-accounts/social-connect-button.hbs
+++ b/addon/templates/components/nypr-accounts/social-connect-button.hbs
@@ -4,7 +4,10 @@
 
 {{else}}
 
-  <button class="nypr-social-connect__button {{buttonClass}}" {{action buttonAction}}><i class="nypr-social-connect__icon fa fa-{{providerIcon}}"></i>
+  <button class="nypr-social-connect__button {{buttonClass}}" {{action buttonAction}}>
+  {{#if providerIcon}}
+    <i class="nypr-social-connect__icon fa fa-{{providerIcon}}"></i>
+  {{/if}}
     Connect with {{providerName}}
   </button>
 

--- a/addon/templates/components/nypr-accounts/social-connect-button.hbs
+++ b/addon/templates/components/nypr-accounts/social-connect-button.hbs
@@ -1,0 +1,11 @@
+{{#if connected}}
+
+  <a class="nypr-social-connect__link" href={{manageUrl}} target="blank" rel="noopener noreferrer">Manage {{providerName}} connection</a>
+
+{{else}}
+
+  <button class="nypr-social-connect__button {{buttonClass}}" {{action buttonAction}}><i class="nypr-social-connect__icon fa fa-{{providerIcon}}"></i>
+    Connect with {{providerName}}
+  </button>
+
+{{/if}}

--- a/app/components/nypr-accounts/social-card.js
+++ b/app/components/nypr-accounts/social-card.js
@@ -1,0 +1,1 @@
+export { default } from 'nypr-account-settings/components/nypr-accounts/social-card';

--- a/app/components/nypr-accounts/social-connect-button.js
+++ b/app/components/nypr-accounts/social-connect-button.js
@@ -1,0 +1,1 @@
+export { default } from 'nypr-account-settings/components/nypr-accounts/social-connect-button';

--- a/app/styles/nypr-account-settings.scss
+++ b/app/styles/nypr-account-settings.scss
@@ -262,3 +262,25 @@
     }
   }
 }
+
+.nypr-social-connect__button {
+  @include btn;
+  @include btn--blue;
+  @include btn--strongtext;
+  white-space: nowrap;
+  text-align: center;
+  height: 36px;
+  width: 218px;
+  > .fa {
+    margin-right: 6px;
+    font-size: 19px;
+    vertical-align: text-bottom;
+  }
+}
+.nypr-social-connect__button--facebook {
+  @include btn--facebook;
+  margin-bottom: 14px;
+}
+.nypr-social-connect__link {
+  font-size: 12px;
+}

--- a/tests/integration/components/nypr-accounts/social-card-test.js
+++ b/tests/integration/components/nypr-accounts/social-card-test.js
@@ -6,20 +6,28 @@ moduleForComponent('nypr-accounts/social-card', 'Integration | Component | nypr 
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{nypr-accounts/social-card}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$('.nypr-social-card__header').length, 1);
+});
 
-  // Template block usage:
+
+test('it yields a connect button', function(assert) {
   this.render(hbs`
-    {{#nypr-accounts/social-card}}
-      template block text
-    {{/nypr-accounts/social-card}}
-  `);
+    {{#nypr-accounts/social-card as |card|}}
+      {{card.connect-button}}
+    {{/nypr-accounts/social-card}}`);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('.nypr-social-connect__button').length, 1);
+});
+
+test('it yields three connect buttons', function(assert) {
+  this.render(hbs`
+    {{#nypr-accounts/social-card as |card|}}
+      {{card.connect-button}}
+      {{card.connect-button}}
+      {{card.connect-button}}
+    {{/nypr-accounts/social-card}}`);
+
+  assert.equal(this.$('.nypr-social-connect__button').length, 3);
 });

--- a/tests/integration/components/nypr-accounts/social-card-test.js
+++ b/tests/integration/components/nypr-accounts/social-card-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('nypr-accounts/social-card', 'Integration | Component | nypr accounts/social card', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{nypr-accounts/social-card}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#nypr-accounts/social-card}}
+      template block text
+    {{/nypr-accounts/social-card}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/nypr-accounts/social-connect-button-test.js
+++ b/tests/integration/components/nypr-accounts/social-connect-button-test.js
@@ -6,20 +6,67 @@ moduleForComponent('nypr-accounts/social-connect-button', 'Integration | Compone
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{nypr-accounts/social-connect-button}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$('.nypr-social-connect').length, 1);
+});
 
-  // Template block usage:
-  this.render(hbs`
-    {{#nypr-accounts/social-connect-button}}
-      template block text
-    {{/nypr-accounts/social-connect-button}}
-  `);
+test('it shows a manage link when connected', function(assert) {
+  let providerName='LoginZone';
+  let manageUrl='http://example.com';
+  this.set('providerName', providerName);
+  this.set('manageUrl', manageUrl);
+  this.render(hbs`{{nypr-accounts/social-connect-button
+    connected=true
+    providerName=providerName
+    manageUrl=manageUrl
+  }}`);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('button').length, 0);
+  assert.equal(this.$('a').length, 1);
+  assert.equal(this.$('a').text().trim(), `Manage ${providerName} connection`);
+  assert.equal(this.$('a').attr('href'), manageUrl);
+});
+
+test('it shows a button when not connected', function(assert) {
+  let providerName='LoginZone';
+  let buttonClass='loginzone-orange';
+  this.set('providerName', providerName);
+  this.set('buttonClass', buttonClass);
+  this.render(hbs`{{nypr-accounts/social-connect-button
+    connected=false
+    providerName=providerName
+    buttonClass=buttonClass
+  }}`);
+
+  assert.equal(this.$('a').length, 0);
+  assert.equal(this.$('button').length, 1);
+  assert.equal(this.$('button').text().trim(), `Connect with ${providerName}`);
+  assert.ok(this.$('button').hasClass(buttonClass));
+});
+
+test('button shows font awesome icon', function(assert) {
+  let providerIcon='loginzone';
+  this.set('providerIcon', providerIcon);
+  this.render(hbs`{{nypr-accounts/social-connect-button
+    connected=false
+    providerIcon=providerIcon
+  }}`);
+
+  assert.equal(this.$('button > i').length, 1);
+  assert.ok(this.$('button > i').hasClass(`fa-${providerIcon}`));
+});
+
+test('button triggers action', function(assert) {
+  let timesButtonWasPressed = 0;
+  let buttonAction = () => timesButtonWasPressed++;
+  this.set('buttonAction', buttonAction);
+  this.render(hbs`{{nypr-accounts/social-connect-button
+    connected=false
+    buttonAction=buttonAction
+  }}`);
+
+  this.$('button').click();
+
+  assert.equal(timesButtonWasPressed, 1);
 });

--- a/tests/integration/components/nypr-accounts/social-connect-button-test.js
+++ b/tests/integration/components/nypr-accounts/social-connect-button-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('nypr-accounts/social-connect-button', 'Integration | Component | nypr accounts/social connect button', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{nypr-accounts/social-connect-button}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#nypr-accounts/social-connect-button}}
+      template block text
+    {{/nypr-accounts/social-connect-button}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Essentialy this is a container for a list of fancy buttons.

We are not currently using the 'connect button' in https://jira.wnyc.org/browse/WE-6871 (it shows when `connected` property of `connect-button` is set to false), but the work was already done and it won't hurt to include the full component right now.