### PR TITLE
Fix tests for ember-beta

### DIFF
--- a/addon/components/nypr-account-forms/reset.js
+++ b/addon/components/nypr-account-forms/reset.js
@@ -18,6 +18,7 @@ const FLASH_MESSAGES = {
 export default Component.extend({
   layout,
   store: service(),
+  flashMessages: service(),
   authAPI: null,
   session: null,
   resendUrl: computed('authAPI', function() {

--- a/tests/integration/components/nypr-account-forms/login-test.js
+++ b/tests/integration/components/nypr-account-forms/login-test.js
@@ -14,7 +14,7 @@ test('it renders', function(assert) {
 });
 
 test('submitting the form passes the login values to the authenticator', function(assert) {
-  let authenticate = sinon.stub().returns(RSVP.Promise.reject({}));
+  let authenticate = sinon.stub().returns(RSVP.Promise.resolve({}));
   let session = {authenticate};
   this.set('session', session);
   this.render(hbs`{{nypr-account-forms/login session=session}}`);


### PR DESCRIPTION
We use the ember-try addon to run tests in several different versions of Ember.

Some tests are failing in the current ember-beta branch and this PR fixes those issues