### PR TITLE
WE-7573 signup error when user has email but no password

### DIFF
--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -31,11 +31,16 @@ export default Component.extend({
   },
   actions: {
     onSubmit() {
+      set(this, 'signupError', null);
       return this.signUp();
     },
     onFailure(e) {
       if (e) {
-        this.applyErrorToChangeset(e.errors, get(this, 'changeset'));
+        if (e.errors && e.errors.code === 'UserNoPassword') {
+          set(this, 'signupError', messages.signupNoPassword);
+        } else {
+          this.applyErrorToChangeset(e.errors, get(this, 'changeset'));
+        }
       }
     },
     signupWithFacebook() {

--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -88,7 +88,7 @@ export default Component.extend({
       changeset.rollback(); // so errors don't stack up
       if (error.code === "AccountExists") {
         changeset.validate('email');
-        changeset.pushErrors('email', `An account already exists for the email ${changeset.get('email')}.<br/> <a href="/login">Log in?</a> <a href="/forgot">Forgot password?</a>`);
+        changeset.pushErrors('email', messages.signupAccountExists(changeset.get('email')));
       } else if (error.message === 'User is disabled') {
         changeset.pushErrors('email', messages.userDisabled);
       }

--- a/addon/templates/components/nypr-account-forms/signup.hbs
+++ b/addon/templates/components/nypr-account-forms/signup.hbs
@@ -79,6 +79,12 @@
       submitted=form.status.tried
     }}
 
+    {{#if signupError}}
+      <div class='account-form-error'>
+        {{{signupError}}}
+      </div>
+    {{/if}}
+
     <div class="account-form-notice">
       By proceeding to create your account, you are agreeing to New York Public Radio’s <a href="/terms" target="_blank">Terms of Service</a> and <a href="/privacy" target="_blank">Privacy Policy</a>.
     </div>

--- a/addon/validations/nypr-accounts/custom-messages.js
+++ b/addon/validations/nypr-accounts/custom-messages.js
@@ -18,6 +18,7 @@ export default {
   publicHandleRequired:  'public handle cannot be blank',
   publicHandleExists:    'public handle already exists',
   emailExists:           'an account with this email address already exists',
+  signupNoPassword:      'It looks like you previously signed up through Facebook. You can log in via the <a href="/login">Facebook button here</a>.',
   genericVerificationError: 'There was a problem verifying your email address. Please try again later.',
   socialAuthCancelled:    "We're sorry, but we weren't able to log you in through Facebook.",
   socialAuthNoEmail:      "Unfortunately, we can't authorize your account without permission to view your email address.",

--- a/addon/validations/nypr-accounts/custom-messages.js
+++ b/addon/validations/nypr-accounts/custom-messages.js
@@ -18,6 +18,7 @@ export default {
   publicHandleRequired:  'public handle cannot be blank',
   publicHandleExists:    'public handle already exists',
   emailExists:           'an account with this email address already exists',
+  signupAccountExists:   email => `An account already exists for the email ${email}.<br/> <a href="/login">Log in?</a> <a href="/forgot">Forgot password?</a>`,
   signupNoPassword:      'It looks like you previously signed up through Facebook. You can log in via the <a href="/login">Facebook button here</a>.',
   genericVerificationError: 'There was a problem verifying your email address. Please try again later.',
   socialAuthCancelled:    "We're sorry, but we weren't able to log you in through Facebook.",

--- a/tests/integration/components/nypr-account-forms/signup-test.js
+++ b/tests/integration/components/nypr-account-forms/signup-test.js
@@ -1,4 +1,4 @@
-import { moduleForComponent, test, skip } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
 import { startMirage }  from 'dummy/initializers/ember-cli-mirage';
@@ -56,22 +56,15 @@ test('submitting the form tries to save values on a new user model', function(as
   });
 });
 
-skip('submitting the form sends a post to the api', function(assert) {
+test('submitting the form in noPassword state shows an error', function(assert) {
   let testFirstName = 'Test';
   let testLastName = 'User';
   let testEmail = 'test@email.com';
   let testPassword = 'password123';
-  let authAPI = 'http://example.com';
-  this.set('authAPI', authAPI);
+  let signUp = () => RSVP.reject({errors: {code: 'UserNoPassword'} });
+  this.set('signUp', signUp);
 
-  let requests = [];
-  let url = `${authAPI}/v1/user`;
-  this.server.post(url, (schema, request) => {
-    requests.push(request);
-    return {};
-  }, 200);
-
-  this.render(hbs`{{nypr-account-forms/signup authAPI=authAPI}}`);
+  this.render(hbs`{{nypr-account-forms/signup signUp=signUp}}`);
 
   this.$('label:contains(First Name) + input').val(testFirstName).blur();
   this.$('label:contains(Last Name) + input').val(testLastName).blur();
@@ -81,13 +74,6 @@ skip('submitting the form sends a post to the api', function(assert) {
   this.$('button:contains(Sign up)').click();
 
   return wait().then(() => {
-    assert.equal(requests.length, 1);
-    assert.deepEqual(JSON.parse(requests[0].requestBody), {
-      given_name: testFirstName,
-      family_name: testLastName,
-      email: testEmail,
-      password: testPassword,
-      preferred_username: null
-    });
+    assert.equal(this.$('.account-form-error').length, 1);
   });
 });


### PR DESCRIPTION
Show an error message when a Facebook user has created an account with email address but not yet set up a password, and they try to sign up with that email address.

https://jira.wnyc.org/browse/WE-7573

This PR also moves the accountExists error message to custom-messages.js and removes a skipped test that was never going to work.