### PR TITLE
Migrate envvars

### DIFF
--- a/addon/components/nypr-accounts/basic-card.js
+++ b/addon/components/nypr-accounts/basic-card.js
@@ -77,7 +77,7 @@ export default Component.extend({
   },
 
   checkForExistingAttribute: task(function * ({key, value, errorMessage}) {
-    let path = `${this.config.wnycAuthAPI}/v1/user/exists-by-attribute`;
+    let path = `${this.config.authAPI}/v1/user/exists-by-attribute`;
     let serverKey = decamelize(key);
     try {
       let response = yield fetch(`${path}?${serverKey}=${value}`);

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,6 +3,6 @@
 
 module.exports = function(environment, appConfig) {
   return {
-    authService: appConfig.wnycAuthAPI
+    authService: appConfig.authAPI
   };
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cookies": "0.0.13",
     "ember-data": "2.14.10",
     "ember-modal-dialog": "0.9.1",
-    "nypr-auth": "nypublicradio/nypr-auth"
+    "nypr-auth": "nypublicradio/nypr-auth#migrate-envvars"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,7 +17,7 @@ module.exports = function(environment) {
         Date: false
       }
     },
-    wnycAuthAPI: '',
+    authAPI: '',
 
     APP: {
       // Here you can pass flags/options to your application instance
@@ -42,7 +42,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
-    ENV.wnycAuthAPI = '';
+    ENV.authAPI = '';
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
Updates to better organize envvars and remove the `wnyc` prefix.

Envvars renamed in this addon:
* `wnycAuthAPI` -> `authAPI`
