### PR TITLE
prefills signup form from queries

### DIFF
--- a/addon/components/nypr-account-forms/signup.js
+++ b/addon/components/nypr-account-forms/signup.js
@@ -22,7 +22,14 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    set(this, 'newUser', this.get('store').createRecord('user'));
+    set(this, 'newUser', this.get('store').createRecord('user',
+      {
+        'givenName': get(this, 'givenName'),
+        'familyName': get(this, 'familyName'),
+        'email': get(this, 'email'),
+        'emailConfirmation': get(this, 'email'),
+      }
+    ));
     set(this, 'changeset', new Changeset(get(this, 'newUser'), lookupValidator(SignupValidations), SignupValidations));
     get(this, 'changeset').validate();
   },


### PR DESCRIPTION
Pre-fills account creation (signup) forms with e-mail address, first, and last name from query string in url. This url is intended to be shared in mailchimp to allow easy signup. 
https://jira.wnyc.org/browse/BT-172