### PR TITLE
Add additional filter to sustaining pledges for is-payment

### DIFF
--- a/addon/components/nypr-accounts/membership-card/giving-history.js
+++ b/addon/components/nypr-accounts/membership-card/giving-history.js
@@ -13,7 +13,10 @@ export default Component.extend({
   sortedSustainingPledges: computed.filterBy(
     "sortedPledges",
     "orderType",
-    "sustainer",
+    "sustainer"
+  ),
+  sortedSustainingPayments: computed.filterBy(
+    "sortedSustainingPledges"
     "isPayment",
     true
   ),

--- a/addon/components/nypr-accounts/membership-card/giving-history.js
+++ b/addon/components/nypr-accounts/membership-card/giving-history.js
@@ -16,7 +16,7 @@ export default Component.extend({
     "sustainer"
   ),
   sortedSustainingPayments: computed.filterBy(
-    "sortedSustainingPledges"
+    "sortedSustainingPledges",
     "isPayment",
     true
   ),

--- a/addon/components/nypr-accounts/membership-card/giving-history.js
+++ b/addon/components/nypr-accounts/membership-card/giving-history.js
@@ -13,7 +13,9 @@ export default Component.extend({
   sortedSustainingPledges: computed.filterBy(
     "sortedPledges",
     "orderType",
-    "sustainer"
+    "sustainer",
+    "isPayment",
+    true
   ),
   sortedOneTimePledges: computed.filterBy(
     "sortedPledges",

--- a/addon/components/nypr-accounts/membership-card/giving-history.js
+++ b/addon/components/nypr-accounts/membership-card/giving-history.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from '../../../templates/components/nypr-accounts/membership-card/giving-history';
+import { get } from '@ember/object';
 import { computed } from '@ember/object';
 
 export default Component.extend({
@@ -15,11 +16,12 @@ export default Component.extend({
     "orderType",
     "sustainer"
   ),
-  sortedSustainingPayments: computed.filterBy(
-    "sortedSustainingPledges",
-    "isPayment",
-    true
-  ),
+  sortedSustainingPayments: computed("sortedSustainerPledges", function() {
+    return this.get("pledges").filter(pledge => {
+      return (get(pledge, "orderType") === "sustainer" &&
+              get(pledge, "isPayment") === true);
+    });
+  }),
   sortedOneTimePledges: computed.filterBy(
     "sortedPledges",
     "orderType",

--- a/addon/templates/components/nypr-accounts/membership-card/giving-history.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card/giving-history.hbs
@@ -1,6 +1,6 @@
   {{#nypr-tabs selection=selection as |tabs|}}
     {{#tabs.tablist as |tablist|}}
-      {{#if sortedSustainingPledges}}
+      {{#if sortedSustainingPayments}}
         {{#tablist.tab "TabA" on-select=(action (mut selection))}}Sustaining donations{{/tablist.tab}}
       {{/if}}
       {{#if sortedOneTimePledges}}
@@ -9,7 +9,7 @@
     {{/tabs.tablist}}
 
     {{#tabs.tabpanel "TabA"}}
-      {{#each sortedSustainingPledges as |pledge|}}
+      {{#each sortedSustainingPayments as |pledge|}}
       <div class="pledge-container pledge-history-container">
         <div class="pledge-date">{{moment-format pledge.orderDate 'MMM D, YYYY'}}</div>
         <div class="pledge-fund-and-premium">

--- a/tests/acceptance/download-tax-letter-test.js
+++ b/tests/acceptance/download-tax-letter-test.js
@@ -9,7 +9,9 @@ module("Acceptance | download tax letter", function(hooks) {
   test("tax letter link is visible", async function(assert) {
     let lastYear = moment().subtract(1, "year").year();
     server.create("user");
-    server.createList("pledge", 20);
+    server.createList("pledge", 1, {
+      orderDate: lastYear + "-03-26T11:57:22.139Z"
+    });
     await visit("/");
 
     assert.equal(

--- a/tests/dummy/app/models/pledge.js
+++ b/tests/dummy/app/models/pledge.js
@@ -15,6 +15,7 @@ export default Model.extend({
   creditCardLast4Digits: attr('string'),
   isActiveMember: attr('boolean'),
   isSustainer: attr('boolean'),
+  isPayment: attr('boolean'),
   updateLink: computed('fund', function() {
     let pledgeDomain = this.get('fund') === 'WQXR' ? 'wqxr' : 'wnyc';
     let fundSlug = this.get('fund').toLowerCase().replace(/[. ]/g, '');

--- a/tests/dummy/mirage/factories/pledge.js
+++ b/tests/dummy/mirage/factories/pledge.js
@@ -12,4 +12,5 @@ export default Factory.extend({
   creditCardLast4Digits: '0302',
   isActiveMember: faker.random.boolean,
   isSustainer: faker.random.boolean,
+  isPayment: faker.random.boolean,
 });

--- a/tests/integration/components/nypr-accounts/membership-card-test.js
+++ b/tests/integration/components/nypr-accounts/membership-card-test.js
@@ -113,6 +113,77 @@ module('Integration | Component | nypr accounts/membership card', function(hooks
     );
   });
 
+  test('sustaining pledge but no payments received so far', async function(assert) {
+    let pledges = server.createList('pledge', 1, {
+      isActiveMember: true,
+      isSustainer: true,
+      orderType: 'sustainer',
+      isPayment: false
+    });
+    let pledgePromise = DS.PromiseArray.create({
+      promise: RSVP.Promise.resolve(pledges)
+    });
+    this.set('pledges', pledgePromise);
+
+    await render(hbs`{{nypr-accounts/membership-card pledges=pledges}}`);
+
+    await click('[data-test-selector="nypr-card-button"]');
+
+    // Should not display the pledge record
+    assert.equal(
+      findAll('.pledge-history-container'),
+      0,
+      'Does not display giving-history tabs'
+    );
+  });
+
+  test('only one sustaining payment, no onetime', async function(assert) {
+    let pledges = server.createList('pledge', 1, {
+      isActiveMember: true,
+      isSustainer: true,
+      orderType: 'sustainer',
+      isPayment: true
+    });
+    let pledgePromise = DS.PromiseArray.create({
+      promise: RSVP.Promise.resolve(pledges)
+    });
+    this.set('pledges', pledgePromise);
+
+    await render(hbs`{{nypr-accounts/membership-card pledges=pledges}}`);
+
+    await click('[data-test-selector="nypr-card-button"]');
+
+    // Should not display the pledge record
+    assert.equal(
+      findAll('div.nypr-tabs-tablist a').length,
+      1,
+      'shows only one tab - the Sustaining Dontations tab'
+    );
+  });
+
+  test('only onetime pledges, no sustaining payments', async function(assert) {
+    let pledges = server.createList('pledge', 1, {
+      isActiveMember: true,
+      orderType: 'onetime',
+      isPayment: true
+    });
+    let pledgePromise = DS.PromiseArray.create({
+      promise: RSVP.Promise.resolve(pledges)
+    });
+    this.set('pledges', pledgePromise);
+
+    await render(hbs`{{nypr-accounts/membership-card pledges=pledges}}`);
+
+    await click('[data-test-selector="nypr-card-button"]');
+
+    // Should not display the pledge record
+    assert.equal(
+      findAll('div.nypr-tabs-tablist a').length,
+      1,
+      'shows only one tab - the One-time donations tab'
+    );
+  });
+
   // Active one-time member tests
 
   test('displays most recent active pledge details if active onetime member', async function(assert) {


### PR DESCRIPTION
- Adds isPayment: true filter to sortedSustainingPledges, in order to not show active sustaining pledges that have received no payments so far.
- I believe this work is dependent on my my change to the order model in wnyc-web-client: https://github.com/nypublicradio/wnyc-web-client/tree/BT-1369-handle-is-payment

Login to demo member center with test user: zzclindstrom2020@aol.comzz:wnycdemo1
Sustaining donations tab - first row is:
May 14, 2019 RadioLab $10

This is only a pledge but no payments have been received on it (is-payment: false)