### PR TITLE
Make custom membership status message more flexible

### DIFF
--- a/addon/components/nypr-accounts/membership-card.js
+++ b/addon/components/nypr-accounts/membership-card.js
@@ -8,9 +8,9 @@ export default Component.extend({
   layout,
   session: service(),
   pledgeManagerEnabled: true,
-  pledgeRedirectMessage: "Manage your account and find your tax documents in a new place.",
-  pledgeRedirectUrl: "https://pledge.wnyc.org/user",
-  pledgeRedirectUrlText: "Manage My Account",
+  customStatusMessage: null,
+  customStatusUrl: null,
+  customStatusUrlText: null,
   previousYear: computed(function() {
     return moment()
       .subtract(1, "year")

--- a/addon/components/nypr-accounts/membership-card.js
+++ b/addon/components/nypr-accounts/membership-card.js
@@ -8,9 +8,9 @@ export default Component.extend({
   layout,
   session: service(),
   pledgeManagerEnabled: true,
-  customStatusMessage: null,
-  customStatusUrl: null,
-  customStatusUrlText: null,
+  customStatusMessage: "",
+  customStatusUrl: "",
+  customStatusUrlText: "",
   previousYear: computed(function() {
     return moment()
       .subtract(1, "year")

--- a/addon/templates/components/nypr-accounts/membership-card.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card.hbs
@@ -3,14 +3,16 @@
 {{#m.panel to=1 classNames="nypr-membership-info" title="My Donation Status" as |card|}}
   {{card.header title="My Donation Status"}}
 
-  {{#unless pledgeManagerEnabled}}
-    <p class="membership-redirect-message">{{pledgeRedirectMessage}}</p>
+  {{#if customStatusMessage}}
+    <p class="membership-redirect-message">{{{customStatusMessage}}}</p>
+  {{/if}}
+  {{#if customStatusUrl}}
     <a
       class="nypr membership-redirect-link"
       href={{pledgeRedirectUrl}}
       target="_blank" rel="noopener"
-      aria-label={{concat pledgeRedirectUrlText ' (Opens in new window)' }} >{{pledgeRedirectUrlText}}</a>
-  {{/unless}}
+      aria-label={{concat customStatusUrlText ' (Opens in new window)' }} >{{customStatusUrl}}</a>
+  {{/if}}
 
   {{#if emailIsPendingVerification}}
     {{#card.alert}}

--- a/addon/templates/components/nypr-accounts/membership-card.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card.hbs
@@ -10,7 +10,7 @@
     <a
       class="nypr membership-custom-link"
       href={{customStatusLinkUrl}}
-      target="_blank" rel="noopener"
+      target="_blank" rel="noopener noreferrer"
       aria-label={{concat customStatusLinkText ' (Opens in new window)' }} >{{customStatusLinkText}}</a>
   {{/if}}
 

--- a/addon/templates/components/nypr-accounts/membership-card.hbs
+++ b/addon/templates/components/nypr-accounts/membership-card.hbs
@@ -4,14 +4,14 @@
   {{card.header title="My Donation Status"}}
 
   {{#if customStatusMessage}}
-    <p class="membership-redirect-message">{{{customStatusMessage}}}</p>
+    <p class="membership-custom-message">{{{customStatusMessage}}}</p>
   {{/if}}
-  {{#if customStatusUrl}}
+  {{#if customStatusLinkUrl}}
     <a
-      class="nypr membership-redirect-link"
-      href={{pledgeRedirectUrl}}
+      class="nypr membership-custom-link"
+      href={{customStatusLinkUrl}}
       target="_blank" rel="noopener"
-      aria-label={{concat customStatusUrlText ' (Opens in new window)' }} >{{customStatusUrl}}</a>
+      aria-label={{concat customStatusLinkText ' (Opens in new window)' }} >{{customStatusLinkText}}</a>
   {{/if}}
 
   {{#if emailIsPendingVerification}}

--- a/tests/integration/components/nypr-accounts/membership-card-test.js
+++ b/tests/integration/components/nypr-accounts/membership-card-test.js
@@ -32,9 +32,9 @@ module('Integration | Component | nypr accounts/membership card', function(hooks
   });
 
   test('it displays the custom message and link', async function(assert) {
-    let message = "Test 123"
-    let link = "http://example.com"
-    let linkText = "Go to another page"
+    const message = "Test 123"
+    const link = "http://example.com"
+    const linkText = "Go to another page"
     this.set('message', message);
     this.set('link', link);
     this.set('linkText', linkText);
@@ -42,18 +42,37 @@ module('Integration | Component | nypr accounts/membership card', function(hooks
     await render(hbs`{{nypr-accounts/membership-card pledgeManagerEnabled=false customStatusMessage=message customStatusLinkUrl=link customStatusLinkText=linkText}}`);
 
     assert.equal(
-      find('.nypr-card-header').textContent.trim(), 'My Donation Status',
+      find('.nypr-card-header').textContent.trim(),
+      'My Donation Status',
       'has membership header'
     );
 
     assert.equal(
-      find('.membership-custom-message').textContent.trim(), message,
+      find('.membership-custom-message').textContent.trim(),
+      message,
       'has custom message'
     );
 
     assert.equal(
-      find('.membership-custom-link').textContent.trim(), linkText,
+      find('.membership-custom-link').textContent.trim(),
+      linkText,
       'has custom link'
+    );
+  });
+
+  test('it does not display the custom message and link when unset', async function(assert) {
+    await render(hbs`{{nypr-accounts/membership-card pledgeManagerEnabled=false}}`);
+
+    assert.equal(
+      findAll('.membership-custom-message'),
+      0,
+      'has no custom message'
+    );
+
+    assert.equal(
+      findAll('.membership-custom-link'),
+      0,
+      'has no custom link'
     );
   });
 

--- a/tests/integration/components/nypr-accounts/membership-card-test.js
+++ b/tests/integration/components/nypr-accounts/membership-card-test.js
@@ -31,16 +31,30 @@ module('Integration | Component | nypr accounts/membership card', function(hooks
     assert.ok(find('.pledge-help-link'), 'has help link');
   });
 
-  test('it displays the redirect message when the pledge manager is disabled', async function(assert) {
-    await render(hbs`{{nypr-accounts/membership-card pledgeManagerEnabled=false}}`);
+  test('it displays the custom message and link', async function(assert) {
+    let message = "Test 123"
+    let link = "http://example.com"
+    let linkText = "Go to another page"
+    this.set('message', message);
+    this.set('link', link);
+    this.set('linkText', linkText);
+
+    await render(hbs`{{nypr-accounts/membership-card pledgeManagerEnabled=false customStatusMessage=message customStatusLinkUrl=link customStatusLinkText=linkText}}`);
 
     assert.equal(
       find('.nypr-card-header').textContent.trim(), 'My Donation Status',
       'has membership header'
     );
 
-    assert.ok(find('.membership-redirect-message'), 'has redirect message');
-    assert.ok(find('.membership-redirect-link'), 'has redirect link');
+    assert.equal(
+      find('.membership-custom-message').textContent.trim(), message,
+      'has custom message'
+    );
+
+    assert.equal(
+      find('.membership-custom-link').textContent.trim(), linkText,
+      'has custom link'
+    );
   });
 
   // Active sustaining member tests


### PR DESCRIPTION
- removes temporary hardcoded default custom status message and link
- hides button and message block when no link or message are provided
- changes status message display to use {{{ triple brackets }}} allowing us to pass in html messages instead of just plain links
- renames parameters to be more generic